### PR TITLE
[Feature:Developer] Stops redundant PRs from being created

### DIFF
--- a/.github/workflows/bump-submitty.yml
+++ b/.github/workflows/bump-submitty.yml
@@ -45,6 +45,6 @@ jobs:
           token: ${{ secrets.SUBMITTYBOT_DEPENDENCY_TOKEN }}
           path: Localization
           commit-message: update version and base lang to ${{ github.event.client_payload.ref_name }}
-          branch: bump-submitty/${{ github.event.client_payload.ref_name }}
+          branch: bump-submitty
           title: "[Dependency] Update Submitty from ${{ steps.version.outputs.prop }} to ${{ github.event.client_payload.ref_name }}"
           body: "Bumps [Submitty](https://github.com/${{ github.repository_owner }}/Submitty) from version [${{ steps.version.outputs.prop }}](https://github.com/${{ github.repository_owner }}/Submitty/releases/tag/${{ steps.version.outputs.prop }}) to [${{ github.event.client_payload.ref_name }}](https://github.com/${{ github.repository_owner }}/Submitty/releases/tag/${{ github.event.client_payload.ref_name }})."


### PR DESCRIPTION
Looking to satisfy issue
- https://github.com/Submitty/Submitty/issues/9741  

Previously:
A new PR would be created for every bump.

New Behavior:
Only one PR will stay open and it will be the PR for the most recent bump.